### PR TITLE
fix ROC

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -490,7 +490,7 @@ class TA:
         The ROC calculation compares the current price with the price “n” periods ago."""
 
         return pd.Series(
-            (ohlc["close"].diff(period) / ohlc["close"][-period]) * 100, name="ROC"
+            (ohlc["close"].diff(period) / ohlc["close"].shift(period)) * 100, name="ROC"
         )
 
     @classmethod


### PR DESCRIPTION
Before pandas would just throw an exception because you can't access a negative index.