### PR TITLE
RSI name to include period if not 14

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -592,7 +592,12 @@ class TA:
         _loss = down.abs().ewm(span=period, adjust=adjust).mean()
 
         RS = _gain / _loss
-        return pd.Series(100 - (100 / (1 + RS)), name="RSI")
+        name = "RSI"
+        if period != 14:
+            name = f"RSI_period_{period}"
+
+        return pd.Series(100 - (100 / (1 + RS)), name=name)
+
 
     @classmethod
     def IFT_RSI(


### PR DESCRIPTION
RSI does not have a period in the name.  I tried to do a faster 7 and a 14 period RSI and found that they were called the same thing so could not distinguish between the 2.

I have left it here that the default 14 will still be called RSI.

Happy for all to be called period 14 but didn't want to break any pipelines later if people were expecting RSI to still be called RSI for the default.
 
Maybe other technicals can be changed to have the default period stay and new periods with the period added.
