### PR TITLE
pandas vectorization (fix EXK)

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -2135,20 +2135,23 @@ class TA:
 
         """
         Excess Kurtosis
+
+        ++ NOTE MESOKURTIC(normal) DISTRIBUTION RETURNS A VALUE OF ~"0.0" ++
+        
+
         Kurtosis measures the "fatness" of the tails of a distribution. Positive excess kurtosis
         means that distribution has fatter tails than a normal distribution. Fat tails means there
         is a higher than normal probability of big positive and negative returns realizations. 
         When calculating kurtosis, a result of +3.00 indicates the absence of kurtosis (distribution is mesokurtic)
         https://www.youtube.com/watch?v=-pb86fuZqr8
 
+        Numpy implementation:
+        sum_of_dist = sum((ohlc[column] - ohlc[column].mean()).pow(4))
+        normalizer = pow(ohlc[column].std(), 4) * len(ohlc[column])
+        return (sum_of_dist / normalizer) - 3
         """
 
-        sum_of_dist = sum((ohlc[column] - ohlc[column].mean()).pow(4))
-
-        normalizer = pow(ohlc[column].std(), 4) * len(ohlc[column])
-
-        return sum_of_dist / normalizer
-
+        return ohlc[column].kurtosis()
 
 if __name__ == "__main__":
     print([k for k in TA.__dict__.keys() if k[0] not in "_"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -829,4 +829,4 @@ def test_exk():
     exk = TA.EXK(ohlc)
 
     assert isinstance(exk, float)
-    assert exk == 4.049110589039371
+    assert exk == 1.0713686592445835


### PR DESCRIPTION
Upon further investigation I realized that the formula provided for EXK was incorrect (excess of kurtosis has a "normal" value ~0). The pandas implementation returned a value ~0.01 away from the numpy method. I believe this may be a result of the large sums being stored. To further make sure it worked I created a 10,000 point normal distribution and got the right results.