### PR TITLE
Fix Chandelier Exit Formula

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -1687,10 +1687,9 @@ class TA:
     def CHANDELIER(
         cls,
         ohlc: DataFrame,
-        period_1: int = 14,
+        period_1: int = 22,
         period_2: int = 22,
         k: int = 3,
-        column: str = "close",
     ) -> DataFrame:
         """
         Chandelier Exit sets a trailing stop-loss based on the Average True Range (ATR).
@@ -1701,11 +1700,11 @@ class TA:
         """
 
         l = pd.Series(
-            ohlc[column].rolling(window=period_2).max() - cls.ATR(ohlc, 22) * k,
+            ohlc["high"].rolling(window=period_2).max() - cls.ATR(ohlc, 22) * k,
             name="Long.",
         )
         s = pd.Series(
-            ohlc[column].rolling(window=period_1).min() - cls.ATR(ohlc, 22) * k,
+            ohlc["low"].rolling(window=period_1).min() + cls.ATR(ohlc, 22) * k,
             name="Short.",
         )
 

--- a/finta/finta.py
+++ b/finta/finta.py
@@ -1687,8 +1687,8 @@ class TA:
     def CHANDELIER(
         cls,
         ohlc: DataFrame,
-        period_1: int = 22,
-        period_2: int = 22,
+        short_period: int = 22,
+        long_period: int = 22,
         k: int = 3,
     ) -> DataFrame:
         """
@@ -1700,11 +1700,11 @@ class TA:
         """
 
         l = pd.Series(
-            ohlc["high"].rolling(window=period_2).max() - cls.ATR(ohlc, 22) * k,
+            ohlc["high"].rolling(window=long_period).max() - cls.ATR(ohlc, 22) * k,
             name="Long.",
         )
         s = pd.Series(
-            ohlc["low"].rolling(window=period_1).min() + cls.ATR(ohlc, 22) * k,
+            ohlc["low"].rolling(window=short_period).min() + cls.ATR(ohlc, 22) * k,
             name="Short.",
         )
 


### PR DESCRIPTION
Fixes formula errors in Chandelier Exit calculation.

[Stockcharts](https://school.stockcharts.com/doku.php?id=technical_indicators:chandelier_exit) defines Chandelier Exit as: 
```
Chandelier Exit (long) = 22-day High - ATR(22) x 3 
Chandelier Exit (short) = 22-day Low + ATR(22) x 3
```
The same formula is shown [here](https://www.incrediblecharts.com/indicators/chandelier_exits.php), [here](https://www.marketvolume.com/technicalanalysis/chandelierexit.asp)

Changes:
- Always use `high` and `low` columns to calculate rolling max and min
- Change `-` to `+` in short calculation
- Change default window in short calculation to 22 (Charles Le Beau recommended using a 22-day window and 22 is more commonly used than 14)