### PR TITLE
Fixed STC calculation + test

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -842,5 +842,5 @@ def test_stc():
     stc = TA.STC(ohlc)
 
     assert isinstance(stc, series.Series)
-    assert stc.values[-1] == 10.000000000000165
+    assert stc.values[-1] == 1.1131836193574902e-13
 


### PR DESCRIPTION
STC calculation is a double smoothed Stoch on the MACD. The source you were using (referenced in doc string) schaff equation makes no sense. This version aligns with what is produced on Yahoo Finance and TOS. 

Calculation:
MACD = macd("close", fast, slow) 
K_LINE, D_LINE = fastStoch(macd, k_period, d_period)
STC = sma(D_LINE, d_period)    // second smoothing on d line

Notes: 
Some sources use a default second smoothing period of 3.  Some default to half the k_period. And some just let you choose the d_period. 

Referenced Source:
https://tlc.thinkorswim.com/center/reference/Tech-Indicators/studies-library/R-S/SchaffTrendCycle