### PR TITLE
added williams fractal indicator

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -2199,5 +2199,43 @@ class TA:
 
         return pd.Series(STOD_DoubleSmooth, name="{0} period EVSTC".format(k_period))
 
+
+    @classmethod
+    def WILLIAMS_FRACTAL(cls, ohlc: DataFrame, period: int = 2) -> DataFrame:
+        """
+        Williams Fractal Indicator
+        Source: https://www.investopedia.com/terms/f/fractal.asp
+
+        :param DataFrame ohlc: data
+        :param int period: how many lower highs/higher lows the extremum value should be preceded and followed.
+        :return DataFrame: fractals identified by boolean
+        """
+
+        def is_bullish_fractal(x):
+            if x[period] == min(x):
+                return True
+            return False
+
+        def is_bearish_fractal(x):
+            if x[period] == max(x):
+                return True
+            return False
+
+        window_size = period * 2 + 1
+        bearish_fractals = pd.Series(
+            ohlc.high.rolling(window=window_size, center=True).apply(
+                is_bearish_fractal, raw=True
+            ),
+            name="BearishFractal",
+        )
+        bullish_fractals = pd.Series(
+            ohlc.low.rolling(window=window_size, center=True).apply(
+                is_bullish_fractal, raw=True
+            ),
+            name="BullishFractal",
+        )
+        return pd.concat([bearish_fractals, bullish_fractals], axis=1)
+
+
 if __name__ == "__main__":
     print([k for k in TA.__dict__.keys() if k[0] not in "_"])

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -856,3 +856,14 @@ def test_evstc():
     assert isinstance(stc, series.Series)
     assert 0 < stc.values[-1] < 100
     assert stc.values[-1] == 4.7665575190573385e-14
+
+
+def test_williams_fractal():
+    """test TA.WILLIAMS_FRACTAL"""
+
+    fractals = TA.WILLIAMS_FRACTAL(ohlc)
+
+    assert isinstance(fractals["BullishFractal"], series.Series)
+    assert isinstance(fractals["BearishFractal"], series.Series)
+    assert fractals.BearishFractal.values[-3] == 0
+    assert fractals.BullishFractal.values[-3] == 0


### PR DESCRIPTION
The indicator itself is simple but I am not sure how to best present it. I just produced two columns, one for bearish and one for bullish fractal, so I used 0/1 to denote whether or not there is a fractal.  Used two columns because its possible for a  candle to have both a  bearish and bullish fractal. 
#51 