### PR TITLE
Fixed Bug that results NaN value in OBV indicator

### DIFF
--- a/finta/finta.py
+++ b/finta/finta.py
@@ -1492,7 +1492,7 @@ class TA:
         ohlcv["OBV"] = np.nan
 
         neg_change = ohlcv[column] < ohlcv[column].shift(1)
-        pos_change = ohlcv[column] > ohlcv[column].shift(1)
+        pos_change = ohlcv[column] >= ohlcv[column].shift(1)
 
         if pos_change.any():
             ohlcv.loc[pos_change, "OBV"] = ohlcv["volume"]


### PR DESCRIPTION
Fixed bug that results in NaN value when the previous close is equaled to the current close
resulting in NaN output