### PR TITLE
Add license_files key-value pair in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,5 @@ setup(
     license="LGPLv3+",
     packages=["finta"],
     install_requires=["pandas", "numpy"],
+    license_files=["LICENSE"]
 )


### PR DESCRIPTION
This will package `LICENSE` into the sdist. Context: I'm trying to get this package onto Conda Forge and they do require the license file bundled into the source distribution.